### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/libgnme"]
 	path = external/libgnme
-	url = git@github.com:hgaburton/libgnme.git
+	url = https://github.com/hgaburton/libgnme.git


### PR DESCRIPTION
submodule libgnme fetching changed from git@github.com to https to allow for installation within github CI.